### PR TITLE
feat: Add `node-esm` template

### DIFF
--- a/scripts/prompt.js
+++ b/scripts/prompt.js
@@ -25,6 +25,10 @@ function TEMPLATES(message) {
         value: 'node-ts'
       },
       {
+        title: 'Node.js - JSDoc/ESM',
+        value: 'node-esm'
+      },
+      {
         title: 'Node.js - CommonJS',
         value: 'node'
       },

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -49,6 +49,10 @@ export function getCommandsFor({ targetDir, template }) {
     case 'node-ts':
       commands.push('npm i', 'npm start');
       break;
+    
+    case 'node-esm':
+      commands.push('npm i', 'npm start');
+      break;
 
     case 'plugin':
       commands.push('bun i', 'bun run dev');

--- a/template-node-esm/.gitignore
+++ b/template-node-esm/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.env
+package-lock.json
+
+node_modules/

--- a/template-node-esm/README.md
+++ b/template-node-esm/README.md
@@ -1,0 +1,14 @@
+# $PROJECT_NAME$
+
+# Setup
+
+Follow these steps to run [Elysia.js](https://elysiajs.com) under [Node.js](https://nodejs.org):
+
+1. Install dependencies
+   ```bash
+   npm i
+   ```
+2. You're ready to go. Checkout the scripts inside [package.json](./package.json)!
+   ```bash
+   npm start
+   ```

--- a/template-node-esm/gitignore
+++ b/template-node-esm/gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.env
+package-lock.json
+
+node_modules/

--- a/template-node-esm/jsconfig.json
+++ b/template-node-esm/jsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-		"target": "esnext",
+        "target": "esnext",
         "moduleResolution": "node",
         "allowJs": true,
         "checkJs": true,

--- a/template-node-esm/jsconfig.json
+++ b/template-node-esm/jsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "esnext",
+		"target": "esnext",
+        "moduleResolution": "node",
+        "allowJs": true,
+        "checkJs": true,
+        "noImplicitAny": true,
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "sourceMap": true,
+        "strict": true
+    },
+    "include": ["main.js", "src/**/*.js"],
+    "exclude": ["node_modules/**"]
+}

--- a/template-node-esm/main.js
+++ b/template-node-esm/main.js
@@ -1,0 +1,10 @@
+import '@bogeychan/elysia-polyfills/node/index.js';
+import { Elysia } from 'elysia';
+
+const app = new Elysia()
+    .get('/', () => ({ hello: 'Node.js👋' }))
+    .listen(8080);
+
+console.log(
+    `🦊 Elysia is running at http://localhost:${app.server?.port}`
+);

--- a/template-node-esm/package.json
+++ b/template-node-esm/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "$PROJECT_NAME$",
+    "private": true,
+    "type": "module",
+    "scripts": {
+      "start": "node ./main.js"
+    },
+    "dependencies": {
+      "@bogeychan/elysia-polyfills": "^0.6.1",
+      "@sinclair/typebox": "^0.31.15",
+      "elysia": "^0.7.12"
+    }
+}
+  

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,3 @@
-declare type Template = 'bun' | 'deno' | 'node-ts' | 'node' | 'plugin';
+declare type Template = 'bun' | 'deno' | 'node-ts' | 'node-esm' | 'node' | 'plugin';
 declare type Options = { template: Template; targetDir: string };
 


### PR DESCRIPTION
## Context for this PR

Aims to satisfy #1 

## Features

- Elysia using vanilla js 
- ESM
- Type checking without opting in to typescript via `jsconfig.js`. Types should be done using JSDoc.

## Does it work?

- [x] Elysia runs using nodejs as runtime
- [x] Type checking on .js files work
- [x] Routes with explicit body type work

Tested on on local system with the following specs and tooling:
- MacOS intel
- Node.js 18.14