### PR TITLE
Update template-bun with improved tsconfig and dedicated typecheck package.json script

### DIFF
--- a/template-bun/.gitignore
+++ b/template-bun/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .env
 node_modules/
+bun.lockb

--- a/template-bun/.gitignore
+++ b/template-bun/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 .env
-
-bun.lockb
 node_modules/

--- a/template-bun/gitignore
+++ b/template-bun/gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.env
+node_modules/

--- a/template-bun/gitignore
+++ b/template-bun/gitignore
@@ -1,5 +1,0 @@
-.DS_Store
-.env
-
-bun.lockb
-node_modules/

--- a/template-bun/package.json
+++ b/template-bun/package.json
@@ -1,10 +1,15 @@
 {
   "name": "$PROJECT_NAME$",
   "type": "module",
+  "scripts": {
+    "start": "bun run main.ts",
+    "typecheck": "tsc"
+  },
   "devDependencies": {
-    "bun-types": "^1.0.1"
+    "bun-types": "^1.0.12",
+    "typescript": "^5.2.2"
   },
   "dependencies": {
-    "elysia": "^0.6.19"
+    "elysia": "^0.7.28"
   }
 }

--- a/template-bun/tsconfig.json
+++ b/template-bun/tsconfig.json
@@ -9,10 +9,8 @@
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
-    "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "types": [

--- a/template-bun/tsconfig.json
+++ b/template-bun/tsconfig.json
@@ -7,10 +7,14 @@
     "target": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "downlevelIteration": true,
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
     "types": [
       "bun-types" // add Bun global
     ]


### PR DESCRIPTION
This PR updates the bun template to enhance TypeScript support, with:

- An updated tsconfig [based off of the recommendations here](https://www.totaltypescript.com/tsconfig-cheat-sheet)
- TypeScript installed by default, allowing typechecking and better editor support from the get-go
- bun.lockb removed from the .gitignore, as this should be committed by default in repositories
- Updated minimum versions of elysia and bun types